### PR TITLE
Insert all opencv header 

### DIFF
--- a/src/loader/loader_base.cpp
+++ b/src/loader/loader_base.cpp
@@ -4,6 +4,7 @@
 #include <boost/filesystem.hpp>
 #include <boost/regex.hpp>
 #include <helper/helper.h>
+#include <opencv2/opencv.hpp>
 
 
 #include "loader_base.h"

--- a/src/loader/loader_base.h
+++ b/src/loader/loader_base.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <vector>
 #include <opencv/highgui.h>
+#include <opencv2/opencv.hpp>
 
 using std::string;
 using std::vector;


### PR DESCRIPTION
The file loader_base.cpp and loader_base.h displays and error saying cv::rectangle is not defined. This header solves the problems and other future problems regarding openCV